### PR TITLE
added assetPairIds field for orderbook updates stream request

### DIFF
--- a/grpc_proto_contracts/publicService.proto
+++ b/grpc_proto_contracts/publicService.proto
@@ -59,6 +59,7 @@ message PriceUpdatesRequest {
 
 message OrderbookUpdatesRequest {
     string assetPairId = 1;
+    repeated string assetPairIds = 2;
 }
 
 message PublicTradesUpdatesRequest {

--- a/source/includes/_change-log.md
+++ b/source/includes/_change-log.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2021-01-11 | Multiple orderbook updates
+
+Added ```assetPairIds``` for orderbook updates stream request to get updates for multiple orderbooks.
+
 ## 2020-10-23 | Public trades endpoint
 
 Added public trades rest api and grpc endpoints.

--- a/source/includes/_public-stream.md
+++ b/source/includes/_public-stream.md
@@ -109,7 +109,9 @@ Please note that if a level is deleted at a specific price, a packet containing 
 
 Parameter | Type | Default | Description
 --------- | ---- | ------- | -----------
-assetPairId | string | null | *(Optional)* Identificator of specific symbol. By default return all symbols.
+assetPairId | string | null | *(Optional)* 
+assetPairIds|string|Array of string|*(Optional)*
+Identificator of specific symbol. By default return all symbols.
 
 ### Request
 
@@ -142,6 +144,7 @@ service PublicService {
 
 message OrderbookUpdatesRequest {
     string assetPairId = 1;
+    repeated string assetPairIds = 2;
 }
 
 message Orderbook {


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->